### PR TITLE
fix(cli): Add missing main function and runtime import to seed registry template

### DIFF
--- a/packages/ormed_cli/lib/src/commands/base/shared.dart
+++ b/packages/ormed_cli/lib/src/commands/base/shared.dart
@@ -291,6 +291,7 @@ const String seedRegistryMarkerEnd = '// </ORM-SEED-REGISTRY>';
 
 const String initialSeedRegistryTemplate =
     '''
+import 'package:ormed_cli/runtime.dart';
 import 'package:ormed/ormed.dart';
 import 'package:{{package_name}}/orm_registry.g.dart';
 
@@ -330,6 +331,13 @@ Future<void> runProjectSeeds(
     pretend: pretend,
   );
 }
+
+Future<void> main(List<String> args) => runSeedRegistryEntrypoint(
+      args: args,
+      seeds: seeders,
+      beforeRun: (connection) =>
+          bootstrapOrm(registry: connection.context.registry),
+    );
 ''';
 
 class OrmProjectContext {


### PR DESCRIPTION
## Summary

Fixes #10 

The `initialSeedRegistryTemplate` in `shared.dart` was missing critical components needed for `ormed seed` to work:

1. `import 'package:ormed_cli/runtime.dart';` - Required for `runSeedRegistryEntrypoint`
2. The `main` function that calls `runSeedRegistryEntrypoint` - Required entry point for `dart run seeders.dart`

## Problem

Running `ormed seed` failed with:
```
Invoked Dart programs must have a 'main' function defined:
https://dart.dev/to/main-function
```
Exit code 253.

## Solution

Added the missing import and main function to the seed registry template to match the expected structure.

## Testing

- Ran `dart tool/test_bootstrap.dart` - all tests pass including seeding