### PR TITLE
feat(cli): use database/{project_name}.sqlite as default path

### DIFF
--- a/packages/ormed_cli/lib/src/commands/base/init_command.dart
+++ b/packages/ormed_cli/lib/src/commands/base/init_command.dart
@@ -74,10 +74,11 @@ class InitCommand extends Command<void> {
       }
     }
 
+    final packageName = getPackageName(root);
     final configFile = File(p.join(root.path, 'ormed.yaml'));
     _writeFile(
       file: configFile,
-      content: defaultOrmYaml,
+      content: defaultOrmYaml(packageName),
       label: 'ormed.yaml',
       force: force,
       tracker: tracker,
@@ -86,7 +87,6 @@ class InitCommand extends Command<void> {
 
     // Load config
     final config = loadOrmProjectConfig(configFile);
-    final packageName = getPackageName(root);
 
     // Directories
     final migrationsDir = Directory(

--- a/packages/ormed_cli/lib/src/commands/base/shared.dart
+++ b/packages/ormed_cli/lib/src/commands/base/shared.dart
@@ -269,11 +269,12 @@ void main(List<String> args) {
 }
 ''';
 
-const String defaultOrmYaml = '''
+/// Generate the default ormed.yaml content with the project-specific database path.
+String defaultOrmYaml(String packageName) => '''
 driver:
   type: sqlite
   options:
-    database: database.sqlite
+    database: database/$packageName.sqlite
 migrations:
   directory: lib/src/database/migrations
   registry: lib/src/database/migrations.dart
@@ -291,6 +292,7 @@ const String seedRegistryMarkerEnd = '// </ORM-SEED-REGISTRY>';
 
 const String initialSeedRegistryTemplate =
     '''
+import 'package:ormed_cli/runtime.dart';
 import 'package:ormed/ormed.dart';
 import 'package:{{package_name}}/orm_registry.g.dart';
 
@@ -330,6 +332,13 @@ Future<void> runProjectSeeds(
     pretend: pretend,
   );
 }
+
+Future<void> main(List<String> args) => runSeedRegistryEntrypoint(
+      args: args,
+      seeds: seeders,
+      beforeRun: (connection) =>
+          bootstrapOrm(registry: connection.context.registry),
+    );
 ''';
 
 class OrmProjectContext {

--- a/tool/test_bootstrap.dart
+++ b/tool/test_bootstrap.dart
@@ -256,7 +256,7 @@ Future<void> verifyFiles() async {
   final files = [
     'lib/src/models/user.orm.dart',
     'lib/orm_registry.g.dart',
-    'database.sqlite',
+    'database/$testDir.sqlite',
   ];
 
   for (final f in files) {
@@ -292,7 +292,7 @@ void main() async {
 
   print('Verifying database content...');
   final ds = DataSource(DataSourceOptions(
-    driver: SqliteDriverAdapter.file('database.sqlite'),
+    driver: SqliteDriverAdapter.file('database/orm_bootstrap_test.sqlite'),
     registry: registry,
   ));
   await ds.init();


### PR DESCRIPTION
## Summary

Changes the default SQLite database path in `ormed.yaml` to be `database/{project_name}.sqlite` instead of just `database.sqlite`.

## Changes

- Changed `defaultOrmYaml` from `const` to function that takes `packageName`
- Updated `init_command.dart` to get package name before writing config and pass it to the template
- Updated `test_bootstrap.dart` to verify the new path pattern
- Also includes the seed registry template fix (missing `main` function and runtime import)

## Why

This makes it clearer which project the database belongs to and follows common naming conventions. For example, a project called `my_app` will now generate:

```yaml
datasources:
  default:
    database: database/my_app.sqlite
```

Instead of:
```yaml
datasources:
  default:
    database: database.sqlite
```

## Testing

- ✅ `dart tool/test_bootstrap.dart` passes
- Verified that `ormed.yaml` generates correct path
- Verified that database file is created at the correct location

Closes #5
Includes fix from #10